### PR TITLE
2.1.4 säkerställ dataintegritet vid strömavbrott

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "vector": "cpp"
+    }
+}

--- a/Chas Advance Arduino/include/arduinoLogger.h
+++ b/Chas Advance Arduino/include/arduinoLogger.h
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 #include <EEPROM.h>
 #include "sensorData.h"
+#include <vector>
 
 // ==== CONFIG ====
 #define LOGGER_MAX_ENTRIES 64 // total number of logs in EEPROM
@@ -24,7 +25,7 @@ public:
     void clearAll();
     void update(bool wifiConnected);
     void logMedian(const SensorData &medianData);
-
+    void createLogFromBatch(std::vector<SensorData> &batch, unsigned long now);    
     bool loggerActive;
 
 private:

--- a/Chas Advance Arduino/include/batchHandler.h
+++ b/Chas Advance Arduino/include/batchHandler.h
@@ -5,6 +5,11 @@
 #include <vector>
 #include <Arduino.h>
 
+struct FailedBatch {
+    String json;
+    uint8_t retries;
+};
+
 void batchSensorReadings(const SensorData &data);
 SensorData calculateMedian(std::vector<SensorData>& buffer);
 std::vector<SensorData>& getBatchBuffer();

--- a/Chas Advance Arduino/include/batchHandler.h
+++ b/Chas Advance Arduino/include/batchHandler.h
@@ -3,10 +3,9 @@
 
 #include "sensorData.h"
 #include <vector>
+#include <Arduino.h>
 
 void batchSensorReadings(const SensorData &data);
 SensorData calculateMedian(std::vector<SensorData>& buffer);
 std::vector<SensorData>& getBatchBuffer();
-
-
 #endif

--- a/Chas Advance Arduino/include/jsonParser.h
+++ b/Chas Advance Arduino/include/jsonParser.h
@@ -8,5 +8,5 @@
 
 String parseJSON(float temperature, float humidity, bool error);
 String createBatchJson(const std::vector<SensorData> &buffer);
-
+SensorData getDataFromJson(const String &json);
 #endif

--- a/Chas Advance Arduino/include/jsonParser.h
+++ b/Chas Advance Arduino/include/jsonParser.h
@@ -4,6 +4,7 @@
 #include <ArduinoJson.h>
 #include <vector>
 #include "SensorData.h"
+#include "log.h"
 
 String parseJSON(float temperature, float humidity, bool error);
 String createBatchJson(const std::vector<SensorData> &buffer);

--- a/Chas Advance Arduino/include/log.h
+++ b/Chas Advance Arduino/include/log.h
@@ -1,7 +1,7 @@
 #ifndef LOG_H
 #define LOG_H
 
-#include "arduinoLogger.h"
+#include <Arduino.h>
 
 enum ErrorType {
     NONE = 0,

--- a/Chas Advance Arduino/include/log.h
+++ b/Chas Advance Arduino/include/log.h
@@ -7,7 +7,8 @@ enum ErrorType {
     NONE = 0,
     TOO_LOW = 1,
     TOO_HIGH = 2,
-    SENSOR_FAIL = 4
+    SENSOR_FAIL = 4,
+    WiFi_FAIL = 5
 };
 
 

--- a/Chas Advance Arduino/include/log.h
+++ b/Chas Advance Arduino/include/log.h
@@ -1,11 +1,18 @@
 #ifndef LOG_H
 #define LOG_H
 
-#include <timeProvider.h>
 #include "arduinoLogger.h"
 
+enum ErrorType {
+    NONE = 0,
+    TOO_LOW = 1,
+    TOO_HIGH = 2,
+    SENSOR_FAIL = 4
+};
+
+
 void logEvent(String eventType, String description, String status);
-void logSensorData(float temperature, float humidity, bool error);
+void logSensorData(float temperature, float humidity, ErrorType errorType);
 void logStartup();
 
 #endif

--- a/Chas Advance Arduino/include/sensorData.h
+++ b/Chas Advance Arduino/include/sensorData.h
@@ -1,11 +1,18 @@
 #ifndef SENSORDATA_H
 #define SENSORDATA_H
 
+#include "log.h"
+#include "thresholds.h"
+
+
 struct SensorData
 {
     float temperature;
     float humidity;
     bool error;
+    ErrorType errorType;
 };
 
+
+bool checkThresholds(SensorData &data, const Thresholds &thresholds);
 #endif

--- a/Chas Advance Arduino/include/sensorData.h
+++ b/Chas Advance Arduino/include/sensorData.h
@@ -4,7 +4,6 @@
 #include "log.h"
 #include "thresholds.h"
 
-
 struct SensorData
 {
     float temperature;
@@ -12,7 +11,6 @@ struct SensorData
     bool error;
     ErrorType errorType;
 };
-
 
 bool checkThresholds(SensorData &data, const Thresholds &thresholds);
 #endif

--- a/Chas Advance Arduino/include/thresholds.h
+++ b/Chas Advance Arduino/include/thresholds.h
@@ -1,0 +1,20 @@
+#ifndef THRESHOLDS_H
+#define THRESHOLDS_H
+
+enum TemperatureMode {
+    ROOM_TEMP,
+    COOLER,
+    FREEZER
+};
+
+struct Thresholds {
+    float minTemperature;
+    float maxTemperature;
+    float minHumidity;
+    float maxHumidity;
+};
+
+Thresholds getThresholdsForMode(TemperatureMode mode);
+
+
+#endif

--- a/Chas Advance Arduino/include/wifiHandler.h
+++ b/Chas Advance Arduino/include/wifiHandler.h
@@ -9,6 +9,8 @@ extern unsigned long wifiConnectStart;
 
 void connectToESPAccessPointAsync();
 void sendDataToESP32(String jsonString);
+bool postToESP32(const String &jsonString);
+void retryFailedBatches();
 void updateLogger();
 
 #endif // WIFIHANDLER_H

--- a/Chas Advance Arduino/src/arduinoLogger.cpp
+++ b/Chas Advance Arduino/src/arduinoLogger.cpp
@@ -137,50 +137,56 @@ void Logger::update(bool wifiConnected)
 {
     std::vector<SensorData> &batch = getBatchBuffer();
     if (batch.empty())
-    {
-        return; // No data to log
-    }
+        return;
 
+    unsigned long now = millis();
+    bool logNow = false;
+
+    // 1. Wi-Fi just disconnected -> log immediately
     if (!wifiConnected && !loggerActive)
     {
-        // Start logging
         loggerActive = true;
-        SensorData medianData = calculateMedian(batch);
-        logMedian(medianData);
-        timeSinceLog = millis();
+        logNow = true;
     }
-    else if (!wifiConnected && loggerActive)
+    // 2. Wi-Fi disconnected, continue logging every minute
+    else if (!wifiConnected && loggerActive && (now - timeSinceLog >= 60000))
     {
-        // Continue logging if 1 minute has passed
-        if (millis() - timeSinceLog >= 60000)
-        {
-            SensorData medianData = calculateMedian(batch);
-            logMedian(medianData);
-            timeSinceLog = millis();
-        }
+        logNow = true;
     }
+    // 3. Wi-Fi reconnected -> log once and stop logging
     else if (wifiConnected && loggerActive)
     {
-        // Log once and then stop logging
-        SensorData medianData = calculateMedian(batch);
-        logMedian(medianData);
+        logNow = true;
         loggerActive = false;
     }
+    if(logNow)
+    createLogFromBatch(batch, now);
+}
 
-    if (loggerActive)
-    {
+void Logger::createLogFromBatch(std::vector<SensorData> &batch, unsigned long now)
+{
+        bool errorLogged = false;
         for (auto &entry : batch)
         {
             if (entry.error)
             {
-                // Log warning if any entry in the batch has an error
+                // Log the first error found
                 log(String(entry.temperature) + "," +
                     String(entry.humidity) + "," +
                     String(static_cast<int>(entry.errorType)));
-                return; // Only log once per batch
+                errorLogged = true;
+                break;
             }
         }
-    }
+
+        if (!errorLogged)
+        {
+            // No errors, log median
+            SensorData medianData = calculateMedian(batch);
+            logMedian(medianData);
+        }
+
+        timeSinceLog = now; // Reset timer
 }
 
 void Logger::logMedian(const SensorData &medianData)

--- a/Chas Advance Arduino/src/arduinoLogger.cpp
+++ b/Chas Advance Arduino/src/arduinoLogger.cpp
@@ -192,6 +192,5 @@ void Logger::createLogFromBatch(std::vector<SensorData> &batch, unsigned long no
 void Logger::logMedian(const SensorData &medianData)
 {
     log(String(medianData.temperature) + "," +
-        String(medianData.humidity) +
-        (medianData.error ? "1" : "0"));
+        String(medianData.humidity) + "0");
 }

--- a/Chas Advance Arduino/src/arduinoLogger.cpp
+++ b/Chas Advance Arduino/src/arduinoLogger.cpp
@@ -166,6 +166,21 @@ void Logger::update(bool wifiConnected)
         logMedian(medianData);
         loggerActive = false;
     }
+
+    if (loggerActive)
+    {
+        for (auto &entry : batch)
+        {
+            if (entry.error)
+            {
+                // Log warning if any entry in the batch has an error
+                log(String(entry.temperature) + "," +
+                    String(entry.humidity) + "," +
+                    String(static_cast<int>(entry.errorType)));
+                return; // Only log once per batch
+            }
+        }
+    }
 }
 
 void Logger::logMedian(const SensorData &medianData)

--- a/Chas Advance Arduino/src/arduinoLogger.cpp
+++ b/Chas Advance Arduino/src/arduinoLogger.cpp
@@ -192,5 +192,5 @@ void Logger::createLogFromBatch(std::vector<SensorData> &batch, unsigned long no
 void Logger::logMedian(const SensorData &medianData)
 {
     log(String(medianData.temperature) + "," +
-        String(medianData.humidity) + "0");
+        String(medianData.humidity) + ",0");
 }

--- a/Chas Advance Arduino/src/batchHandler.cpp
+++ b/Chas Advance Arduino/src/batchHandler.cpp
@@ -6,6 +6,7 @@
 static std::vector<SensorData> batchBuffer;
 static unsigned long batchStartTime = 0;
 extern Logger logger;
+extern TemperatureMode currentMode; 
 
 void batchSensorReadings(const SensorData &data)
 {
@@ -30,7 +31,7 @@ SensorData calculateMedian(std::vector<SensorData> &buffer)
 
     for (const auto &data : buffer)
     {
-        if (!data.error)
+        if (!data.errorType == ErrorType::SENSOR_FAIL)
         {
             temps.push_back(data.temperature);
             hums.push_back(data.humidity);

--- a/Chas Advance Arduino/src/batchHandler.cpp
+++ b/Chas Advance Arduino/src/batchHandler.cpp
@@ -31,7 +31,7 @@ SensorData calculateMedian(std::vector<SensorData> &buffer)
 
     for (const auto &data : buffer)
     {
-        if (!data.errorType == ErrorType::SENSOR_FAIL)
+        if (data.errorType != ErrorType::SENSOR_FAIL)
         {
             temps.push_back(data.temperature);
             hums.push_back(data.humidity);

--- a/Chas Advance Arduino/src/batchHandler.cpp
+++ b/Chas Advance Arduino/src/batchHandler.cpp
@@ -33,7 +33,7 @@ SensorData calculateMedian(std::vector<SensorData> &buffer)
 
     for (const auto &data : buffer)
     {
-        if (!data.errorType == ErrorType::SENSOR_FAIL)
+        if (data.errorType != ErrorType::SENSOR_FAIL)
         {
             temps.push_back(data.temperature);
             hums.push_back(data.humidity);

--- a/Chas Advance Arduino/src/batchHandler.cpp
+++ b/Chas Advance Arduino/src/batchHandler.cpp
@@ -5,6 +5,8 @@
 
 static std::vector<SensorData> batchBuffer;
 static unsigned long batchStartTime = 0;
+unsigned long batchSendInterval = 30000;
+
 extern Logger logger;
 extern TemperatureMode currentMode; 
 
@@ -15,7 +17,7 @@ void batchSensorReadings(const SensorData &data)
     if (batchStartTime == 0)
         batchStartTime = millis();
 
-    if (millis() - batchStartTime >= 30000)
+    if (millis() - batchStartTime >= batchSendInterval)
     {
         String batchJson = createBatchJson(batchBuffer);
         sendDataToESP32(batchJson);

--- a/Chas Advance Arduino/src/jsonParser.cpp
+++ b/Chas Advance Arduino/src/jsonParser.cpp
@@ -1,11 +1,13 @@
 #include "jsonParser.h"
 
+//not used?
 String parseJSON(float temperature, float humidity, bool error)
 {
     StaticJsonDocument<200> doc;
     doc["temperature"] = temperature;
     doc["humidity"] = humidity;
     doc["error"] = error;
+    doc["errorType"] = static_cast<int>(error ? SENSOR_FAIL : NONE);
 
     String jsonString;
     serializeJson(doc, jsonString);
@@ -23,6 +25,7 @@ String createBatchJson(const std::vector<SensorData> &buffer)
         obj["temperature"] = entry.temperature;
         obj["humidity"] = entry.humidity;
         obj["error"] = entry.error;
+        obj["errorType"] = static_cast<int>(entry.errorType);
     }
     String output;
     serializeJson(arr, output);

--- a/Chas Advance Arduino/src/jsonParser.cpp
+++ b/Chas Advance Arduino/src/jsonParser.cpp
@@ -1,6 +1,6 @@
 #include "jsonParser.h"
 
-//not used?
+// Deprecated: This function is currently unused but retained for legacy support or future use.
 String parseJSON(float temperature, float humidity, bool error)
 {
     StaticJsonDocument<200> doc;

--- a/Chas Advance Arduino/src/jsonParser.cpp
+++ b/Chas Advance Arduino/src/jsonParser.cpp
@@ -31,3 +31,30 @@ String createBatchJson(const std::vector<SensorData> &buffer)
     serializeJson(arr, output);
     return output;
 }
+
+SensorData getDataFromJson(const String &json) {
+    SensorData data;
+    
+    StaticJsonDocument<200> doc;
+    DeserializationError dError = deserializeJson(doc, json);
+
+    if (dError) {
+        Serial.print("JSON parse error: ");
+        Serial.println(dError.c_str());
+
+        // Return default error value
+        data.temperature = 0.0;
+        data.humidity = 0.0;
+        data.error = true;
+        data.errorType = SENSOR_FAIL;
+        return data;
+    }
+
+    data.temperature = doc["temperature"] | 0.0;
+    data.humidity = doc["humidity"] | 0.0;
+    data.error = doc["error"] | false;
+    int errorTypeInt = doc["errorType"] | 0;
+    data.errorType = static_cast<ErrorType>(errorTypeInt);
+
+    return data;
+}

--- a/Chas Advance Arduino/src/log.cpp
+++ b/Chas Advance Arduino/src/log.cpp
@@ -1,7 +1,5 @@
 #include "log.h"
 
-extern Logger logger;
-
 void logEvent(String eventType, String description, String status)
 {
 

--- a/Chas Advance Arduino/src/log.cpp
+++ b/Chas Advance Arduino/src/log.cpp
@@ -4,6 +4,7 @@ extern Logger logger;
 
 void logEvent(String eventType, String description, String status)
 {
+
     Serial.print(eventType);
     Serial.print(" ");
     Serial.print(description);
@@ -11,17 +12,28 @@ void logEvent(String eventType, String description, String status)
     Serial.println(status);
 }
 
-void logSensorData(float temperature, float humidity, bool error)
+void logSensorData(float temperature, float humidity, ErrorType errorType)
 {
-    if (error)
+    char buffer[50];
+    snprintf(buffer, sizeof(buffer), "Temp=%.1f Hum=%.1f", temperature, humidity);
+
+    switch (errorType)
     {
-        logEvent("ERROR", "No data", "FAIL");
-    }
-    else
-    {
-        char buffer[50];
-        snprintf(buffer, sizeof(buffer), "Temp=%.1f Hum=%.1f", temperature, humidity);
+    case NONE:
         logEvent("INFO", buffer, "OK");
+        break;
+    case TOO_LOW:
+        logEvent("WARNING_Sensor data too low", buffer, "CHECK");
+        break;
+    case TOO_HIGH:
+        logEvent("WARNING_Sensor data too high", buffer, "CHECK");
+        break;
+    case SENSOR_FAIL:
+        logEvent("ERROR", "Sensor failure", "FAIL");
+        break;
+    default:
+        logEvent("ERROR", "Unknown error type", "FAIL");
+        break;
     }
 }
 

--- a/Chas Advance Arduino/src/main.cpp
+++ b/Chas Advance Arduino/src/main.cpp
@@ -54,5 +54,7 @@ void loop()
   batchSensorReadings(data);
   logSensorData(data.temperature, data.humidity, data.errorType);
 
+  retryFailedBatches();
+  
   delay(2000);
 }

--- a/Chas Advance Arduino/src/main.cpp
+++ b/Chas Advance Arduino/src/main.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include "SensorData.h"
 #include "batchHandler.h"
+#include "arduinoLogger.h"
 
 #define DHTPIN 8
 #define DHTTYPE DHT11
@@ -43,8 +44,10 @@ void loop()
     data.error = true;
     data.errorType = SENSOR_FAIL;
   }
-  checkThresholds(data, getThresholdsForMode(currentMode));
-
+  if (!data.error)
+  {
+    checkThresholds(data, getThresholdsForMode(currentMode));
+  }
   connectToESPAccessPointAsync();
   updateLogger();
 

--- a/Chas Advance Arduino/src/main.cpp
+++ b/Chas Advance Arduino/src/main.cpp
@@ -56,5 +56,5 @@ void loop()
 
   retryFailedBatches();
   
-  delay(2000);
+  delay(3000);
 }

--- a/Chas Advance Arduino/src/sensorData.cpp
+++ b/Chas Advance Arduino/src/sensorData.cpp
@@ -1,0 +1,18 @@
+#include "sensorData.h"
+
+bool checkThresholds(SensorData &data, const Thresholds &thresholds)
+{
+    bool exceeded = false;
+
+    if(data.temperature < thresholds.minTemperature || data.temperature > thresholds.maxTemperature) {
+        exceeded = true;
+        data.error = true; 
+        data.errorType = (data.temperature < thresholds.minTemperature) ? TOO_LOW : TOO_HIGH;
+    }
+    if(data.humidity < thresholds.minHumidity || data.humidity > thresholds.maxHumidity) {
+        exceeded = true;
+        data.error = true;
+        data.errorType = (data.humidity < thresholds.minHumidity) ? TOO_LOW : TOO_HIGH;
+    }
+    return exceeded;
+}

--- a/Chas Advance Arduino/src/thresholds.cpp
+++ b/Chas Advance Arduino/src/thresholds.cpp
@@ -1,0 +1,14 @@
+#include "thresholds.h"
+
+Thresholds roomTempThresholds = { 18.0, 25.0, 30.0, 70.0 };
+Thresholds coolerThresholds   = { 2.0, 6.0, 30.0, 70.0 };
+Thresholds freezerThresholds  = { -30.0, -18.0, 30.0, 70.0 };
+
+Thresholds getThresholdsForMode(TemperatureMode mode) {
+    switch(mode) {
+        case ROOM_TEMP: return roomTempThresholds;
+        case COOLER:    return coolerThresholds;
+        case FREEZER:   return freezerThresholds;
+        default:       return roomTempThresholds;
+    }
+}

--- a/Chas Advance Arduino/src/wifiHandler.cpp
+++ b/Chas Advance Arduino/src/wifiHandler.cpp
@@ -147,7 +147,7 @@ void retryFailedBatches()
                 SensorData data = getDataFromJson(batch.json);
                 data.errorType = ErrorType::WiFi_FAIL;
                 logger.log(String(data.temperature) + "," +
-                           String(data.humidity) + "0" + 
+                           String(data.humidity) + "," + 
                            String(static_cast<int>(data.errorType)));
                 for (int j = i; j < failedBatchCount - 1; j++)
                     failedBatches[j] = failedBatches[j + 1];

--- a/Chas Advance Arduino/src/wifiHandler.cpp
+++ b/Chas Advance Arduino/src/wifiHandler.cpp
@@ -1,11 +1,17 @@
 #include "wifiHandler.h"
 #include "arduinoLogger.h"
 #include "ARDUINOSECRETS.h"
+#include "batchHandler.h"
+#include "jsonParser.h"
 
 extern Logger logger;
 
 bool wifiConnecting = false;
 unsigned long wifiConnectStart = 0;
+
+#define MAX_FAILED_BATCHES 5
+FailedBatch failedBatches[MAX_FAILED_BATCHES];
+uint8_t failedBatchCount = 0;
 
 void connectToESPAccessPointAsync()
 {
@@ -34,20 +40,60 @@ void connectToESPAccessPointAsync()
 
 void sendDataToESP32(String jsonString)
 {
-
     if (WiFi.status() != WL_CONNECTED)
     {
         Serial.println("WiFi not connected, reconnecting...");
         connectToESPAccessPointAsync();
     }
 
+    const int maxRetries = 3;
+    bool success = false;
+
+    for (int attempt = 1; attempt <= maxRetries; attempt++)
+    {
+        Serial.print("Sending batch attempt ");
+        Serial.print(attempt);
+        Serial.print("/");
+        Serial.print(maxRetries);
+        Serial.println("...");
+
+        if (postToESP32(jsonString))
+        {
+            success = true;
+            break;
+        }
+
+        Serial.println("Send failed, retrying...");
+        delay(2000); // Wait before retrying
+    }
+
+    if (!success)
+    {
+        Serial.println("ERROR: Batch send failed after 3 attempts.");
+        // Log error in EEPROM, optional
+        // logger.log("Batch send failed after 3 attempts");
+        if (failedBatchCount < MAX_FAILED_BATCHES)
+        {
+            failedBatches[failedBatchCount++] = {jsonString, 1};
+            Serial.println("Batch queued for later retry");
+        }
+        else
+        {
+            Serial.println("Queue full, batch discarded");
+        }
+    }
+}
+
+bool postToESP32(const String &jsonString)
+{
+    // Simulate batch send failure
+    // return false;
     WiFiClient client;
 
     if (!client.connect(host, port))
     {
         Serial.println("Connection to ESP32 failed");
-        delay(2000);
-        return;
+        return false;
     }
 
     // Send HTTP POST request to the esp
@@ -58,7 +104,58 @@ void sendDataToESP32(String jsonString)
                  "Connection: close\r\n\r\n" +
                  jsonString);
 
+    unsigned long timeout = millis();
+    while (client.connected() && millis() - timeout < 2000)
+    {
+        if (client.available())
+        {
+            String line = client.readStringUntil('\n');
+            if (line.startsWith("HTTP/1.1 200"))
+            {
+                Serial.println("POST successful!");
+                client.stop();
+                return true;
+            }
+        }
+    }
+
+    Serial.println("No valid response from ESP32");
     client.stop();
+    return false;
+}
+
+void retryFailedBatches()
+{
+    for (int i = 0; i < failedBatchCount; i++)
+    {
+        FailedBatch &batch = failedBatches[i];
+        if (postToESP32(batch.json))
+        {
+            Serial.println("Retry succeeded for batch");
+            // Remove batch from queue
+            for (int j = i; j < failedBatchCount - 1; j++)
+                failedBatches[j] = failedBatches[j + 1];
+            failedBatchCount--; // Reduce batches by one
+            i--;                // adjust index
+        }
+        else
+        {
+            batch.retries++;
+            if (batch.retries >= 3)
+            {
+                Serial.println("Retry limit reached, discarding batch");
+                SensorData data = getDataFromJson(batch.json);
+                data.errorType = ErrorType::WiFi_FAIL;
+                logger.log(String(data.temperature) + "," +
+                           String(data.humidity) + "0" + 
+                           String(static_cast<int>(data.errorType)));
+                for (int j = i; j < failedBatchCount - 1; j++)
+                    failedBatches[j] = failedBatches[j + 1];
+                failedBatchCount--;
+                i--;
+            }
+        }
+    }
 }
 
 void updateLogger()

--- a/Chas Advance ESP32/include/espLogger.h
+++ b/Chas Advance ESP32/include/espLogger.h
@@ -1,42 +1,36 @@
 #ifndef ESPLOGGER_H
 #define ESPLOGGER_H
 
-#include <Arduino.h>
+#include "FS.h"
+#include "LittleFS.h"
 #include <ArduinoJson.h>
+#include "sensorDataHandler.h"
 
-// Max number of log entries
-#define LOGGER_MAX_ENTRIES 20
-// Max length of each log message
-#define LOGGER_MSG_LENGTH 100
-
-class Logger {
+class ESPLogger {
 public:
-    Logger();
+    ESPLogger();
     void begin();
 
-    // Add a log entry
-    void log(const String &msg);
+    // Error logging
+    void logError(const String &msg);
+    void printErrors();
 
-    // Print all log entries to Serial
-    void printAll();
+    // Batch logging
+    void logBatch(JsonArray arr);      
+    void printBatches();               
+    bool getOldestBatch(String &out);  
+    void removeOldestBatch();          
 
-    // Get a specific log entry by index
-    String getEntry(size_t index);
-
-    // Get number of stored log entries
-    size_t size();
-
-    void update(bool wifiConnected, JsonArray arr);
+    // Generic utils
+    void clearErrors();
+    void clearBatches();
 
 private:
-    void load();
-    void saveLastEntry();
-    void clearAll();
+    const char *ERROR_FILE = "/errors.txt";
+    const char *BATCH_FILE = "/batches.txt";
+    const size_t MAX_BATCHES = 20;
 
-    char buffer[LOGGER_MAX_ENTRIES][LOGGER_MSG_LENGTH];
-    size_t head;   // index of the next write position
-    size_t count;  // number of valid entries
-    bool loggerActive;
+    size_t countBatches();           
 };
 
 #endif

--- a/Chas Advance ESP32/include/espLogger.h
+++ b/Chas Advance ESP32/include/espLogger.h
@@ -5,32 +5,133 @@
 #include "LittleFS.h"
 #include <ArduinoJson.h>
 #include "sensorDataHandler.h"
+#include <CRC32.h>
 
-class ESPLogger {
+#define MAX_ENTRIES 16
+
+struct SensorEntry
+{
+    uint32_t timestamp;   /**< Unix timestamp of the sensor reading */
+    float temperature;    /**< Temperature value */
+    float humidity;       /**< Humidity value */
+    bool error;           /**< Whether there was an error in this reading */
+    uint8_t errorType;    /**< Type of error, if any */
+};
+
+/**
+ * @brief Batch structure to store multiple sensor entries with CRC.
+ */
+struct Batch
+{
+    uint16_t numEntries;
+    SensorEntry entries[MAX_ENTRIES];
+    uint32_t crc32; /**< CRC of timestamp + numEntries + entries */
+};
+
+/**
+ * @brief ESPLogger handles error logging and batch sensor logging to LittleFS.
+ */
+class ESPLogger
+{
 public:
+    /** @brief Constructor */
     ESPLogger();
+
+    /**
+     * @brief Initializes LittleFS filesystem and prints status to Serial.
+     */
     void begin();
 
-    // Error logging
+    // -------- Error logging --------
+    
+    /**
+     * @brief Logs an error message to the error file with timestamp.
+     * @param msg Error message string.
+     */
     void logError(const String &msg);
+
+    /**
+     * @brief Prints all saved error messages to Serial.
+     */
     void printErrors();
 
-    // Batch logging
-    void logBatch(JsonArray arr);      
-    void printBatches();               
-    bool getOldestBatch(String &out);  
-    void removeOldestBatch();          
-
-    // Generic utils
+    /**
+     * @brief Clears all stored error messages.
+     */
     void clearErrors();
+
+    // -------- Batch logging --------
+    
+    /**
+     * @brief Logs a batch of sensor readings to LittleFS.
+     * @param arr JSON array of sensor objects (must contain temperature, humidity, error, errorType)
+     */
+    void logBatch(JsonArray arr);
+
+    /**
+     * @brief Prints all valid batch files and their entries to Serial.
+     */
+    void printBatches();
+
+    /**
+     * @brief Retrieves the oldest valid batch from storage.
+     * @param outEntries Vector to store sensor entries.
+     * @param batchIndex Index of the batch file.
+     * @return True if a valid batch was retrieved, false otherwise.
+     */
+    bool getOldestBatch(std::vector<SensorEntry> &outEntries, uint16_t &batchIndex);
+
+    /**
+     * @brief Removes the oldest batch file from storage.
+     */
+    void removeOldestBatch();
+
+    /**
+     * @brief Deletes all batch files from storage.
+     */
     void clearBatches();
 
-private:
-    const char *ERROR_FILE = "/errors.txt";
-    const char *BATCH_FILE = "/batches.txt";
-    const size_t MAX_BATCHES = 20;
+    // -------- Batch file utilities --------
+    
+    /**
+     * @brief Generates the filename for a batch index.
+     * @param index Batch index number.
+     * @return Full path string for the batch file.
+     */
+    String getBatchFilename(uint16_t index);
 
-    size_t countBatches();           
+    /**
+     * @brief Returns a sorted list of all batch indices currently stored.
+     * @return Vector of batch indices.
+     */
+    std::vector<uint16_t> getBatchIndices();
+
+    /**
+     * @brief Reads a batch file, validates CRC and returns sensor entries.
+     * @param fname Filename of the batch.
+     * @param outEntries Vector to store sensor entries.
+     * @return True if the batch is valid and read successfully.
+     */
+    bool readBatchFile(const String &fname, std::vector<SensorEntry> &outEntries);
+
+    /**
+     * @brief Prints a vector of sensor entries to Serial.
+     * @param entries Vector of SensorEntry objects.
+     */
+    void printEntries(const std::vector<SensorEntry> &entries);
+
+    // -------- Timestamp utilities --------
+    
+    /**
+     * @brief Converts a timestamp string into a Unix timestamp.
+     * @param tsStr Timestamp string (format: "YYYY-MM-DD HH:MM:SS").
+     * @return Unix timestamp (seconds since 1970).
+     */
+    uint32_t timestampStringToUnix(const String &tsStr);
+
+private:
+    const char *ERROR_FILE = "/errors.txt";  /**< Path to error log file */
+    const size_t MAX_BATCHES = 20;           /**< Maximum number of batch files stored */
 };
 
 #endif

--- a/Chas Advance ESP32/include/jsonParser.h
+++ b/Chas Advance ESP32/include/jsonParser.h
@@ -4,6 +4,6 @@
 #include "log.h"
 
 void parseJson(String json);
-void parseJsonArray(JsonArray arr, const String &timestamp);
+void parseJsonArray(JsonArray& arr, const String &timestamp);
 
 #endif

--- a/Chas Advance ESP32/include/log.h
+++ b/Chas Advance ESP32/include/log.h
@@ -21,5 +21,7 @@ void logSensorData(String timestamp, float temperature, float humidity, ErrorTyp
 void logStartup();
 void checkDataTimeout(unsigned long &timeSinceDataReceived);
 String getTimeStamp();
+String formatUnixTime(uint32_t ts);
+
 
 #endif

--- a/Chas Advance ESP32/include/log.h
+++ b/Chas Advance ESP32/include/log.h
@@ -3,13 +3,21 @@
 
 #include <Arduino.h>
 
+enum ErrorType {
+    NONE = 0,
+    TOO_LOW = 1,
+    TOO_HIGH = 2,
+    SENSOR_FAIL = 4
+};
+
+
 extern const char *ntpServer;
 const long gmtOffset_sec = 3600;
 const int daylightOffset_sec = 3600;
 const int dataReceivedThreshold = 70000; // 70 seconds
 
 void logEvent(String timestamp, String eventType, String description, String status);
-void logSensorData(String timestamp, float temperature, float humidity, bool error);
+void logSensorData(String timestamp, float temperature, float humidity, ErrorType errorType);
 void logStartup();
 void checkDataTimeout(unsigned long &timeSinceDataReceived);
 String getTimeStamp();

--- a/Chas Advance ESP32/include/sensorDataHandler.h
+++ b/Chas Advance ESP32/include/sensorDataHandler.h
@@ -4,12 +4,14 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <vector>
+#include "log.h"
 
 struct SensorData
 {
     float temperature;
     float humidity;
     bool error;
+
 };
 
 float median(std::vector<float>& values);

--- a/Chas Advance ESP32/include/sensorDataHandler.h
+++ b/Chas Advance ESP32/include/sensorDataHandler.h
@@ -11,7 +11,7 @@ struct SensorData
     float temperature;
     float humidity;
     bool error;
-
+    ErrorType errorType;
 };
 
 float median(std::vector<float>& values);

--- a/Chas Advance ESP32/include/wifiHandler.h
+++ b/Chas Advance ESP32/include/wifiHandler.h
@@ -8,16 +8,20 @@
 #include "jsonParser.h"
 #include <time.h>
 
-//initialize wifi setup
+// initialize wifi setup
 void initWifi();
-//Connects the ESP32 to the WiFi network
+// Connects the ESP32 to the WiFi network
 void connectToWiFi();
-//Sets up the Access Point for the Arduino to connect to
+// Sets up the Access Point for the Arduino to connect to
 void setupAccessPoint();
-//Sets up the HTTP server to handle incoming requests
+// Sets up the HTTP server to handle incoming requests
 void setupHttpServer();
-//Handles incoming POST requests to /data
+// Handles incoming POST requests to /data
 void handlePostRequest();
+// Retry sending saved batches
+void trySendPendingBatches();
+// Send a batch to API
+bool postToServer(JsonArray &arr);
 
 extern unsigned long timeSinceDataReceived;
 extern WebServer server; // Server listen to port 80

--- a/Chas Advance ESP32/partitions_littlefs.csv
+++ b/Chas Advance ESP32/partitions_littlefs.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x140000,
+app1,     app,  ota_1,   0x150000,0x140000,
+spiffs,   data, spiffs,  0x290000,0x170000,

--- a/Chas Advance ESP32/platformio.ini
+++ b/Chas Advance ESP32/platformio.ini
@@ -16,3 +16,6 @@ lib_deps =
 	bblanchon/ArduinoJson
 	arduino-libraries/NTPClient@^3.2.1
 monitor_speed = 115200
+board_build.partitions = partitions_littlefs.csv
+upload_protocol = esptool
+

--- a/Chas Advance ESP32/platformio.ini
+++ b/Chas Advance ESP32/platformio.ini
@@ -15,7 +15,7 @@ framework = arduino
 lib_deps = 
 	bblanchon/ArduinoJson
 	arduino-libraries/NTPClient@^3.2.1
+	bakercp/CRC32@^2.0.0
 monitor_speed = 115200
 board_build.partitions = partitions_littlefs.csv
 upload_protocol = esptool
-

--- a/Chas Advance ESP32/src/espLogger.cpp
+++ b/Chas Advance ESP32/src/espLogger.cpp
@@ -134,19 +134,37 @@ void Logger::update(bool Connected, JsonArray arr)
     SensorData medianLog = calcMedian(arr);
     String timeStamp = getTimeStamp();
 
-    if(!Connected && !loggerActive)
+    if (!Connected && !loggerActive)
     {
         log("Server disconnected, starting logger");
         loggerActive = true;
     }
-    else if(!Connected && loggerActive)
+    else if (!Connected && loggerActive)
     {
         String logEntry = timeStamp + " Temp: " + String(medianLog.temperature, 2) + " C, Humidity: " + String(medianLog.humidity, 2) + " %";
         log(logEntry);
     }
-    else if(Connected && loggerActive)
+    else if (Connected && loggerActive)
     {
         log("Server connected, stopping logger");
         loggerActive = false;
+    }
+
+    if (loggerActive)
+    {
+        for (JsonObject obj : arr)
+        {
+            int errorTypeInt = obj["errorType"] | 0;
+            ErrorType errorType = static_cast<ErrorType>(errorTypeInt);
+            bool error = obj["error"] | false;
+            if (error)
+            {
+                String logEntry = timeStamp + " T: " +
+                                  String(medianLog.temperature, 2) + " C, H: " +
+                                  String(medianLog.humidity, 2) + " % Err: " + String(errorTypeInt);
+                log(logEntry);
+                break; // Log only once per batch if any error is found
+            }
+        }
     }
 }

--- a/Chas Advance ESP32/src/espLogger.cpp
+++ b/Chas Advance ESP32/src/espLogger.cpp
@@ -25,7 +25,7 @@ void ESPLogger::logError(const String &msg)
     }
 
     String timeStamp = getTimeStamp();
-    f.printf("%s | Code:%d | %s\n", timeStamp.c_str(), msg.c_str());
+    f.printf("%s | %s\n", timeStamp.c_str(), msg.c_str());
     f.close();
 }
 

--- a/Chas Advance ESP32/src/espLogger.cpp
+++ b/Chas Advance ESP32/src/espLogger.cpp
@@ -1,5 +1,4 @@
 #include "espLogger.h"
-#include <CRC32.h>
 
 ESPLogger::ESPLogger() {}
 
@@ -30,64 +29,6 @@ void ESPLogger::logError(const String &msg)
     f.close();
 }
 
-// Batch logging
-void ESPLogger::logBatch(JsonArray arr)
-{
-    // Check number of batches
-    size_t n = countBatches();
-    if (n >= MAX_BATCHES)
-    {
-        removeOldestBatch(); // Remove oldest - circular buffering
-    }
-
-    File f = LittleFS.open(BATCH_FILE, FILE_APPEND);
-    if (!f)
-    {
-        Serial.println("Failed to open batch log");
-        return;
-    }
-
-    StaticJsonDocument<1024> doc;
-    doc["timestamp"] = getTimeStamp();
-    JsonArray data = doc.createNestedArray("data");
-
-    for (JsonObject obj : arr)
-    {
-        JsonObject e = data.createNestedObject();
-        e["t"] = obj["temperature"] | 0.0;
-        e["h"] = obj["humidity"] | 0.0;
-        e["err"] = obj["error"] | false;
-        e["et"] = obj["errorType"] | 0;
-    }
-
-    String jsonStr;
-    serializeJson(doc, jsonStr);
-
-    // Calc CRC32 checksum
-    uint32_t crc = CRC32::calculate(jsonStr.c_str(), jsonStr.length());
-    crc = 9999999; // Wrong CRC for testing
-    // write JSON + checksum
-    f.printf("%s|%08X\n", jsonStr.c_str(), crc);
-    f.close();
-}
-
-void ESPLogger::printBatches()
-{
-    File f = LittleFS.open(BATCH_FILE, FILE_READ);
-    if (!f)
-    {
-        Serial.println("No batch log found");
-        return;
-    }
-    Serial.println("---- Batch log start ----");
-    while (f.available())
-    {
-        Serial.println(f.readStringUntil('\n'));
-    }
-    Serial.println("---- Batch log end ----");
-    f.close();
-}
-
 void ESPLogger::printErrors()
 {
     File f = LittleFS.open(ERROR_FILE, FILE_READ);
@@ -105,80 +46,248 @@ void ESPLogger::printErrors()
     f.close();
 }
 
-bool ESPLogger::getOldestBatch(String &out)
-{
-    File f = LittleFS.open(BATCH_FILE, FILE_READ);
-    if (!f)
-        return false;
-
-    String line = f.readStringUntil('\n');
-    f.close();
-
-    int sep = line.lastIndexOf("|CRC:");
-    if (sep == -1)
-    {
-        logError("Corrupt batch: " + line);
-        removeOldestBatch();
-        return false;
-    }
-
-    String jsonPart = line.substring(0, sep);
-    uint32_t savedCrc = line.substring(sep + 5).toInt();
-    uint32_t calcCrc = CRC32::calculate(jsonPart.c_str(), jsonPart.length());
-
-    if (savedCrc != calcCrc)
-    {
-        Serial.println("Corrupt data detected, removing batch");
-        logError("Corrupt batch: " + line);
-        removeOldestBatch();   
-        return false;
-    }
-
-    out = jsonPart;
-    return true;
-}
-
-void ESPLogger::removeOldestBatch()
-{
-    File f = LittleFS.open(BATCH_FILE, FILE_READ);
-    if (!f)
-        return;
-
-    String rest = "";
-    f.readStringUntil('\n'); // Skip first line
-    while (f.available())
-    {
-        rest += f.readStringUntil('\n') + "\n"; // Save every line
-    }
-    f.close();
-
-    File fw = LittleFS.open(BATCH_FILE, FILE_WRITE);
-    fw.print(rest); // Write all lines except first(oldest)
-    fw.close();
-}
-
-// Utils
 void ESPLogger::clearErrors()
 {
     LittleFS.remove(ERROR_FILE);
 }
 
-void ESPLogger::clearBatches()
+void ESPLogger::logBatch(JsonArray arr)
 {
-    LittleFS.remove(BATCH_FILE);
+    std::vector<SensorEntry> entries;
+
+    // Convert JSON objects to SensorEntry structs
+    for (JsonObject obj : arr)
+    {
+        SensorEntry entry;
+        entry.timestamp = timestampStringToUnix(getTimeStamp());
+        entry.temperature = obj["temperature"] | 0.0f;
+        entry.humidity = obj["humidity"] | 0.0f;
+        entry.error = obj["error"] | false;
+        entry.errorType = obj["errorType"] | 0;
+        entries.push_back(entry);
+    }
+
+    if (entries.empty())
+    {
+        Serial.println("No valid entries in JSON array; batch not logged");
+        return;
+    }
+
+    // Calculate CRC for integrity check
+    uint32_t crc = CRC32::calculate((uint8_t *)entries.data(), entries.size() * sizeof(SensorEntry));
+    
+    //crc = 9999; // For testing, force bad CRC
+
+    // Determine next batch index
+    auto indices = getBatchIndices();
+    uint16_t nextIndex = indices.empty() ? 0 : indices.back() + 1;
+
+    // Keep batch count below MAX_BATCHES
+    if (indices.size() >= MAX_BATCHES)
+    {
+        Serial.println("Max batch files reached; removing oldest batch");
+        removeOldestBatch();
+    }
+
+    String fname = getBatchFilename(nextIndex);
+    Serial.printf("Creating batch file: %s\n", fname.c_str());
+
+    File f = LittleFS.open(fname, FILE_WRITE);
+    if (!f)
+    {
+        Serial.printf("Failed to open batch file %s for writing\n", fname.c_str());
+        logError("Failed to create batch file");
+        return;
+    }
+
+    uint16_t count = entries.size();
+    size_t written = 0;
+    written += f.write((uint8_t *)&count, sizeof(count));
+    written += f.write((uint8_t *)entries.data(), count * sizeof(SensorEntry));
+    written += f.write((uint8_t *)&crc, sizeof(crc));
+    f.close();
+
+    Serial.printf("Logged batch %d with %d entries, total bytes written: %d\n",
+                  nextIndex, count, (int)written);
 }
 
-size_t ESPLogger::countBatches()
+void ESPLogger::printBatches()
 {
-    File f = LittleFS.open(BATCH_FILE, FILE_READ);
-    if (!f)
-        return 0;
-    size_t n = 0;
-    while (f.available())
+    auto indices = getBatchIndices();
+    if (indices.empty())
     {
-        f.readStringUntil('\n');
-        n++;
+        Serial.println("No batch log found");
+        return;
     }
+
+    Serial.println("---- Batch log start ----");
+
+    for (uint16_t idx : indices)
+    {
+        String fname = getBatchFilename(idx);
+        std::vector<SensorEntry> entries;
+        // Read and validate batch file
+        if (!readBatchFile(fname, entries))
+        {
+            Serial.printf("Corrupt batch %s skipped\n", fname.c_str());
+            continue;
+        }
+        Serial.printf("Batch file: %s\n", fname.c_str());
+        printEntries(entries);
+        Serial.println("-- End of batch --");
+    }
+
+    Serial.println("---- Batch log end ----");
+}
+
+bool ESPLogger::getOldestBatch(std::vector<SensorEntry> &outEntries, uint16_t &batchIndex)
+{
+    auto indices = getBatchIndices();
+    if (indices.empty())
+        return false;
+
+    batchIndex = indices.front(); // oldest batch
+    String fname = getBatchFilename(batchIndex);
+
+    if (!readBatchFile(fname, outEntries))
+    {
+        Serial.printf("Batch %s is corrupted, removing file\n", fname.c_str());
+        LittleFS.remove(fname);
+        return false;
+    }
+
+    return true;
+}
+
+void ESPLogger::removeOldestBatch()
+{
+    auto indices = getBatchIndices();
+    if (indices.empty())
+        return;
+
+    String fname = getBatchFilename(indices.front());
+    Serial.printf("Removing oldest batch: %s\n", fname.c_str());
+    LittleFS.remove(fname);
+}
+
+void ESPLogger::clearBatches()
+{
+    auto indices = getBatchIndices();
+    for (uint16_t idx : indices)
+    {
+        String fname = getBatchFilename(idx);
+        Serial.printf("Removing batch file: %s\n", fname.c_str());
+        LittleFS.remove(fname);
+    }
+}
+
+// -------- Batch file utilities --------
+String ESPLogger::getBatchFilename(uint16_t index)
+{
+    return "/batch_" + String(index) + ".bin";
+}
+
+std::vector<uint16_t> ESPLogger::getBatchIndices()
+{
+    std::vector<uint16_t> indices;
+    File root = LittleFS.open("/");
+    File file = root.openNextFile();
+    while (file)
+    {
+        String name = file.name();
+        if (!name.startsWith("/"))
+            name = "/" + name;
+
+        if (name.startsWith("/batch_") && name.endsWith(".bin"))
+        {
+            uint16_t idx = name.substring(7, name.length() - 4).toInt();
+            indices.push_back(idx);
+            Serial.printf("Found batch file: %s, index: %d\n", name.c_str(), idx);
+        }
+        file = root.openNextFile();
+    }
+    std::sort(indices.begin(), indices.end());
+    return indices;
+}
+
+bool ESPLogger::readBatchFile(const String &fname, std::vector<SensorEntry> &outEntries)
+{
+    File f = LittleFS.open(fname, FILE_READ);
+    if (!f)
+        return false;
+
+    outEntries.clear();
+
+    // File too small to contain count + CRC
+    if (f.size() < sizeof(uint16_t) + sizeof(uint32_t))
+    {
+        f.close();
+        return false;
+    }
+
+    uint16_t count = 0;
+    if (f.read((uint8_t *)&count, sizeof(count)) != sizeof(count) || count == 0 || count > 100)
+    {
+        f.close();
+        return false;
+    }
+
+    if (f.size() < sizeof(uint16_t) + count * sizeof(SensorEntry) + sizeof(uint32_t))
+    {
+        f.close();
+        return false;
+    }
+
+    outEntries.resize(count);
+    if (f.read((uint8_t *)outEntries.data(), count * sizeof(SensorEntry)) != count * sizeof(SensorEntry))
+    {
+        f.close();
+        return false;
+    }
+
+    uint32_t savedCrc = 0;
+    if (f.read((uint8_t *)&savedCrc, sizeof(savedCrc)) != sizeof(savedCrc))
+    {
+        f.close();
+        return false;
+    }
+
     f.close();
-    return n;
+
+    uint32_t calcCrc = CRC32::calculate((uint8_t *)outEntries.data(), count * sizeof(SensorEntry));
+    if (calcCrc != savedCrc)
+        return false;
+
+    return true;
+}
+
+uint32_t ESPLogger::timestampStringToUnix(const String &tsStr)
+{
+    struct tm timeinfo = {0};
+
+    if (sscanf(tsStr.c_str(), "%4d-%2d-%2d %2d:%2d:%2d",
+               &timeinfo.tm_year, &timeinfo.tm_mon, &timeinfo.tm_mday,
+               &timeinfo.tm_hour, &timeinfo.tm_min, &timeinfo.tm_sec) != 6)
+    {
+        Serial.println("Failed to parse timestamp");
+        return 0;
+    }
+
+    timeinfo.tm_year -= 1900; // struct tm expects years since 1900
+    timeinfo.tm_mon -= 1;     // struct tm months are 0-11
+
+    return (uint32_t)mktime(&timeinfo);
+}
+
+void ESPLogger::printEntries(const std::vector<SensorEntry> &entries)
+{
+    for (const auto &entry : entries)
+    {
+        Serial.printf("Timestamp: %s, Temp: %.2f, Hum: %.2f, Error: %d, ErrorType: %d\n",
+                      formatUnixTime(entry.timestamp).c_str(),
+                      entry.temperature,
+                      entry.humidity,
+                      entry.error,
+                      entry.errorType);
+    }
 }

--- a/Chas Advance ESP32/src/espLogger.cpp
+++ b/Chas Advance ESP32/src/espLogger.cpp
@@ -1,170 +1,158 @@
 #include "espLogger.h"
-#include <Preferences.h>
-#include "sensorDataHandler.h"
-#include "log.h"
 
-// Create a global Preferences object for ESP32 non-volatile storage
-Preferences prefs;
+ESPLogger::ESPLogger() {}
 
-// Constructor initializes internal buffer counters
-Logger::Logger() : head(0), count(0) {}
-
-// Initialize the logger
-void Logger::begin()
+void ESPLogger::begin()
 {
-    Serial.println("Logger init for ESP32");
-
-    loggerActive = false;
-    // Open the "logger" namespace in Preferences
-    // false = read/write mode
-    prefs.begin("logger", false);
-
-    // Optional: clear all logs in NVS for testing
-    // prefs.clear();
-
-    // Load existing logs from flash into RAM buffer
-    load();
-}
-
-// Add a new log entry
-void Logger::log(const String &msg)
-{
-    Serial.println("Logging on ESP32: " + msg);
-    // Copy the String message into the fixed-size char buffer
-    // Truncate if longer than LOGGER_MSG_LENGTH - 1
-    msg.substring(0, LOGGER_MSG_LENGTH - 1).toCharArray(buffer[head], LOGGER_MSG_LENGTH);
-
-    // Advance the head pointer (circular buffer)
-    head = (head + 1) % LOGGER_MAX_ENTRIES;
-
-    // Increase count until it reaches max entries
-    if (count < LOGGER_MAX_ENTRIES)
-        count++;
-
-    // Persist only the latest entry and update metadata
-    saveLastEntry();
-}
-
-// Print all stored logs to Serial in order from oldest to newest
-void Logger::printAll()
-{
-    Serial.println("---- Log start ----");
-    for (size_t i = 0; i < count; i++)
+    if (!LittleFS.begin(true))
     {
-        Serial.println(getEntry(i));
+        Serial.println("LittleFS mount failed");
     }
-    Serial.println("---- Log end ----");
-}
-
-// Retrieve a single log entry by index (0 = oldest)
-String Logger::getEntry(size_t index)
-{
-    if (index >= count)
-        return ""; // Return empty if index is out of bounds
-
-    // Calculate the real index in the circular buffer
-    size_t realIndex = (head + LOGGER_MAX_ENTRIES - count + index) % LOGGER_MAX_ENTRIES;
-
-    // Convert char array to String for ease of use
-    return String(buffer[realIndex]);
-}
-
-// Return the number of log entries currently stored
-size_t Logger::size()
-{
-    return count;
-}
-
-// Load logs from non-volatile storage into RAM buffer
-void Logger::load()
-{
-    // Read stored count and head from Preferences
-    count = prefs.getUInt("count", 0);
-    if (count > LOGGER_MAX_ENTRIES)
-        count = LOGGER_MAX_ENTRIES; // Ensure we don't exceed buffer
-
-    head = prefs.getUInt("head", 0);
-
-    // Load each stored log into RAM buffer
-    for (size_t i = 0; i < count; i++)
+    else
     {
-        String s = prefs.getString(("log" + String(i)).c_str(), ""); // default to empty
-        s.toCharArray(buffer[i], LOGGER_MSG_LENGTH);                 // store as fixed-size char array
+        Serial.println("LittleFS mounted successfully");
     }
 }
 
-// Persist only the most recently added entry to Preferences
-void Logger::saveLastEntry()
+// -------- Error logging --------
+void ESPLogger::logError(const String &msg)
 {
-    // Save metadata: total count and head pointer
-    prefs.putUInt("count", count);
-    prefs.putUInt("head", head);
-
-    // Calculate index of the last added log (circular buffer)
-    size_t lastIndex = (head + LOGGER_MAX_ENTRIES - 1) % LOGGER_MAX_ENTRIES;
-
-    // Save only the latest log entry to NVS
-    prefs.putString(("log" + String(lastIndex)).c_str(), buffer[lastIndex]);
-}
-
-// Clear all logs from RAM and non-volatile storage
-void Logger::clearAll()
-{
-    for (size_t i = 0; i < count; i++)
+    File f = LittleFS.open(ERROR_FILE, FILE_APPEND);
+    if (!f)
     {
-        // Remove each log key from Preferences
-        prefs.remove(("log" + String(i)).c_str());
-
-        // Clear the RAM buffer
-        memset(buffer[i], 0, LOGGER_MSG_LENGTH);
+        Serial.println("Failed to open error log");
+        return;
     }
 
-    // Reset counters
-    count = 0;
-    head = 0;
-
-    // Update metadata in Preferences
-    prefs.putUInt("count", count);
-    prefs.putUInt("head", head);
-}
-
-void Logger::update(bool Connected, JsonArray arr)
-{
-    // Compute median of the entire array
-    SensorData medianLog = calcMedian(arr);
     String timeStamp = getTimeStamp();
+    f.printf("%s | Code:%d | %s\n", timeStamp.c_str(), msg.c_str());
+    f.close();
+}
 
-    if (!Connected && !loggerActive)
+// Batch logging
+void ESPLogger::logBatch(JsonArray arr)
+{
+    // Check number of batches
+    size_t n = countBatches();
+    if (n >= MAX_BATCHES)
     {
-        log("Server disconnected, starting logger");
-        loggerActive = true;
-    }
-    else if (!Connected && loggerActive)
-    {
-        String logEntry = timeStamp + " Temp: " + String(medianLog.temperature, 2) + " C, Humidity: " + String(medianLog.humidity, 2) + " %";
-        log(logEntry);
-    }
-    else if (Connected && loggerActive)
-    {
-        log("Server connected, stopping logger");
-        loggerActive = false;
+        // Remove oldest - circular buffering
+        removeOldestBatch();
     }
 
-    if (loggerActive)
+    File f = LittleFS.open(BATCH_FILE, FILE_APPEND);
+    if (!f)
     {
-        for (JsonObject obj : arr)
-        {
-            int errorTypeInt = obj["errorType"] | 0;
-            ErrorType errorType = static_cast<ErrorType>(errorTypeInt);
-            bool error = obj["error"] | false;
-            if (error)
-            {
-                String logEntry = timeStamp + " T: " +
-                                  String(medianLog.temperature, 2) + " C, H: " +
-                                  String(medianLog.humidity, 2) + " % Err: " + String(errorTypeInt);
-                log(logEntry);
-                break; // Log only once per batch if any error is found
-            }
-        }
+        Serial.println("Failed to open batch log");
+        return;
     }
+
+    StaticJsonDocument<1024> doc;
+    doc["timestamp"] = getTimeStamp();
+    JsonArray data = doc.createNestedArray("data");
+
+    for (JsonObject obj : arr)
+    {
+        JsonObject e = data.createNestedObject();
+        e["t"] = obj["temperature"] | 0.0;
+        e["h"] = obj["humidity"] | 0.0;
+        e["err"] = obj["error"] | false;
+        e["et"] = obj["errorType"] | 0;
+    }
+
+    String jsonStr;
+    serializeJson(doc, jsonStr);
+
+    f.println(jsonStr);
+    f.close();
+}
+
+void ESPLogger::printBatches()
+{
+    File f = LittleFS.open(BATCH_FILE, FILE_READ);
+    if (!f)
+    {
+        Serial.println("No batch log found");
+        return;
+    }
+    Serial.println("---- Batch log start ----");
+    while (f.available())
+    {
+        Serial.println(f.readStringUntil('\n'));
+    }
+    Serial.println("---- Batch log end ----");
+    f.close();
+}
+
+void ESPLogger::printErrors()
+{
+    File f = LittleFS.open(ERROR_FILE, FILE_READ);
+    if (!f)
+    {
+        Serial.println("No Error log found");
+        return;
+    }
+    Serial.println("---- Error log start ----");
+    while (f.available())
+    {
+        Serial.println(f.readStringUntil('\n'));
+    }
+    Serial.println("---- Error log end ----");
+    f.close();
+}
+
+bool ESPLogger::getOldestBatch(String &out)
+{
+    File f = LittleFS.open(BATCH_FILE, FILE_READ);
+    if (!f)
+        return false;
+
+    out = f.readStringUntil('\n');
+    f.close();
+    return out.length() > 0;
+}
+
+void ESPLogger::removeOldestBatch()
+{
+    File f = LittleFS.open(BATCH_FILE, FILE_READ);
+    if (!f)
+        return;
+
+    String rest = "";
+    f.readStringUntil('\n'); // Skip first line
+    while (f.available())
+    {
+        rest += f.readStringUntil('\n') + "\n"; // Save every line
+    }
+    f.close();
+
+    File fw = LittleFS.open(BATCH_FILE, FILE_WRITE);
+    fw.print(rest); // Write all lines except first(oldest)
+    fw.close();
+}
+
+// Utils
+void ESPLogger::clearErrors()
+{
+    LittleFS.remove(ERROR_FILE);
+}
+
+void ESPLogger::clearBatches()
+{
+    LittleFS.remove(BATCH_FILE);
+}
+
+size_t ESPLogger::countBatches()
+{
+    File f = LittleFS.open(BATCH_FILE, FILE_READ);
+    if (!f)
+        return 0;
+    size_t n = 0;
+    while (f.available())
+    {
+        f.readStringUntil('\n');
+        n++;
+    }
+    f.close();
+    return n;
 }

--- a/Chas Advance ESP32/src/jsonParser.cpp
+++ b/Chas Advance ESP32/src/jsonParser.cpp
@@ -18,8 +18,10 @@ void parseJson(String json)
     float temperature = doc["temperature"] | 0.0;
     float humidity = doc["humidity"] | 0.0;
     bool error = doc["error"] | false;
+    int errorTypeInt = doc["errorType"] | 0; // safe fallback
+    ErrorType errorType = static_cast<ErrorType>(errorTypeInt);
 
-    logSensorData(timestamp, temperature, humidity, error);
+    logSensorData(timestamp, temperature, humidity, errorType);
 }
 
 void parseJsonArray(JsonArray arr, const String &timestamp)

--- a/Chas Advance ESP32/src/jsonParser.cpp
+++ b/Chas Advance ESP32/src/jsonParser.cpp
@@ -24,7 +24,7 @@ void parseJson(String json)
     logSensorData(timestamp, temperature, humidity, errorType);
 }
 
-void parseJsonArray(JsonArray arr, const String &timestamp)
+void parseJsonArray(JsonArray& arr, const String &timestamp)
 {
     for (JsonObject obj : arr)
     {

--- a/Chas Advance ESP32/src/log.cpp
+++ b/Chas Advance ESP32/src/log.cpp
@@ -71,3 +71,13 @@ String getTimeStamp()
     }
     return timeStamp;
 }
+
+//Convert unix timestamp to formatted string
+String formatUnixTime(uint32_t ts)
+{
+    time_t t = ts;
+    struct tm *timeinfo = localtime(&t);
+    char buffer[20];
+    strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", timeinfo);
+    return String(buffer);
+}

--- a/Chas Advance ESP32/src/log.cpp
+++ b/Chas Advance ESP32/src/log.cpp
@@ -13,17 +13,24 @@ void logEvent(String timestamp, String eventType, String description, String sta
     Serial.println(status);
 }
 
-void logSensorData(String timestamp, float temperature, float humidity, bool error)
+void logSensorData(String timestamp, float temperature, float humidity, ErrorType errorType)
 {
-    if (error)
+    char buffer[50];
+    snprintf(buffer, sizeof(buffer), "Temp=%.1f Hum=%.1f", temperature, humidity);
+
+    switch (errorType)
     {
-        logEvent(timestamp, "ERROR", "No data", "FAIL");
-    }
-    else
-    {
-        char buffer[50];
-        snprintf(buffer, sizeof(buffer), "Temp=%.1f Hum=%.1f", temperature, humidity);
-        logEvent(timestamp, "INFO", buffer, "OK");
+    case NONE:
+        logEvent(timestamp,"INFO", buffer, "OK");
+        break;
+    case TOO_LOW:
+        logEvent(timestamp,"WARNING_Sensor data too low", buffer, "CHECK");
+        break;
+    case TOO_HIGH:
+        logEvent(timestamp,"WARNING_Sensor data too high", buffer, "CHECK");
+        break;
+    case SENSOR_FAIL:
+        logEvent(timestamp,"ERROR", "Sensor failure", "FAIL");
     }
 }
 

--- a/Chas Advance ESP32/src/main.cpp
+++ b/Chas Advance ESP32/src/main.cpp
@@ -2,6 +2,7 @@
 #include "mockJson.h"
 #include "wifiHandler.h"
 #include "espLogger.h"
+#include "esp_system.h"
 
 ESPLogger logger;
 
@@ -10,10 +11,13 @@ void setup()
   Serial.begin(115200);
   delay(3000);
   Serial.println("Starting ESP32...");
+  Serial.print("Reset reason: ");
+  Serial.println(esp_reset_reason());
 
   //Initialize logger
   logger.begin();
   logStartup();
+  //logger.clearBatches(); // For testing, clear old batches
 
   // Print all previous log entries
   logger.printBatches();

--- a/Chas Advance ESP32/src/main.cpp
+++ b/Chas Advance ESP32/src/main.cpp
@@ -3,7 +3,7 @@
 #include "wifiHandler.h"
 #include "espLogger.h"
 
-Logger logger;
+ESPLogger logger;
 
 void setup()
 {
@@ -16,7 +16,8 @@ void setup()
   logStartup();
 
   // Print all previous log entries
-  logger.printAll();
+  logger.printBatches();
+  logger.printErrors();
 
   initWifi();
 }
@@ -24,8 +25,8 @@ void setup()
 void loop()
 {
   checkDataTimeout(timeSinceDataReceived);
-
   server.handleClient();
+  trySendPendingBatches();
   delay(1000);
 }
 


### PR DESCRIPTION
# Pull Request

## Beskrivning
<!-- Kort beskrivning av vad denna PR gör och varför den behövs -->
- La till checksummor - ett sätt att kolla att data har skrivits klart till filen. Vid strömavbrott kan filer lämnas halvfärdiga och med checksummor kan man radera korrupt data. 
Denna PR lägger även till att data loggas i flashminnet som binär data för att förbättra minnesanvändning.

## Typ av ändring
<!-- Kryssa i det som passar -->
- [x] Ny funktionalitet
- [ ] Buggfix
- [ ] Refaktorering
- [ ] Dokumentation
- [ ] Test

## Checklista
<!-- Kontrollera innan PR kan mergas -->
- [x] Kod kompilerar / byggs utan fel
- [ ] Enhetstester har körts och passerat
- [ ] Kod följer kodstandard/linting
- [ ] Nödvändiga ändringar i dokumentation gjorda
- [x] Branch är uppdaterad med senaste `main` / `develop`

## Testinstruktioner
<!-- Beskriv hur denna PR kan testas manuellt eller automatiskt -->
Håll utkik efter prints som: Serial.printf("Corrupt batch %s skipped\n", fname.c_str()); 
Normalt kommer data ej bli korrupt: om detta vill testas kan man 
sätta crc till något hårdkodat värde. <img width="969" height="103" alt="image" src="https://github.com/user-attachments/assets/355d0aad-9d2e-4908-8cbb-0b202d91d7de" />
- La till print för reset reason ifall ESP crashar. 1 = normal reset. 

## Skärmdumpar / exempel
<!-- Lägg gärna till bilder, diagram eller logs om relevant -->

## Påverkan
- [ ] Backend
- [ ] Frontend
- [x] Embedded / Firmware
- [ ] Infrastruktur / CI/CD
- [ ] Annat (beskriv):

## Relaterade ärenden / tasks
<!-- Koppla PR till Jira/GitHub issues eller interna tasks -->
- Task-ID: 2.1.4
- Feature:2.1

## Kommentarer till granskare
<!-- Speciellt att tänka på vid granskning -->
- Eventuella risker
- Om något behöver testas extra noga
- Särskilda delar av koden som är komplexa
